### PR TITLE
Modify 1.9.0 to incorporate celery fixes due in 1.9.1

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -295,6 +295,13 @@ default_queue = default
 # Import path for celery configuration options
 celery_config_options = airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG
 
+[celery_broker_transport_options]
+# The visibility timeout defines the number of seconds to wait for the worker
+# to acknowledge the task before the message is redelivered to another worker.
+# Make sure to increase the visibility timeout to match the time of the longest
+# ETA you’re planning to use. Especially important in case of using Redis or SQS
+visibility_timeout = 21600
+
 [dask]
 # This section only applies if you are using the DaskExecutor in
 # [core] section above

--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -19,6 +19,10 @@ from airflow import configuration
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 
+broker_transport_options = configuration.getsection('celery_broker_transport_options')
+if broker_transport_options is None:
+    broker_transport_options = {'visibility_timeout': 21600}
+
 DEFAULT_CELERY_CONFIG = {
     'accept_content': ['json', 'pickle'],
     'event_serializer': 'json',
@@ -28,7 +32,7 @@ DEFAULT_CELERY_CONFIG = {
     'task_default_queue': configuration.get('celery', 'DEFAULT_QUEUE'),
     'task_default_exchange': configuration.get('celery', 'DEFAULT_QUEUE'),
     'broker_url': configuration.get('celery', 'BROKER_URL'),
-    'broker_transport_options': {'visibility_timeout': 21600},
+    'broker_transport_options': {'visibility_timeout': broker_transport_options},
     'result_backend': configuration.get('celery', 'CELERY_RESULT_BACKEND'),
     'worker_concurrency': configuration.getint('celery', 'CELERYD_CONCURRENCY'),
 }

--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -32,9 +32,9 @@ DEFAULT_CELERY_CONFIG = {
     'task_default_queue': configuration.get('celery', 'DEFAULT_QUEUE'),
     'task_default_exchange': configuration.get('celery', 'DEFAULT_QUEUE'),
     'broker_url': configuration.get('celery', 'BROKER_URL'),
-    'broker_transport_options': {'visibility_timeout': broker_transport_options},
-    'result_backend': configuration.get('celery', 'CELERY_RESULT_BACKEND'),
-    'worker_concurrency': configuration.getint('celery', 'CELERYD_CONCURRENCY'),
+    'broker_transport_options': broker_transport_options,
+    'result_backend': configuration.get('celery', 'RESULT_BACKEND'),
+    'worker_concurrency': configuration.getint('celery', 'WORKER_CONCURRENCY'),
 }
 
 celery_ssl_active = False

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -233,6 +233,12 @@ class AirflowConfigParser(ConfigParser):
         ConfigParser.read(self, filenames)
         self._validate()
 
+    def getsection(self, section):
+        if section in self._sections:
+            return self._sections[section]
+
+        return None
+
     def as_dict(self, display_source=False, display_sensitive=False):
         """
         Returns the current configuration as an OrderedDict of OrderedDicts.
@@ -418,6 +424,10 @@ def getfloat(section, key):
 
 def getint(section, key):
     return conf.getint(section, key)
+
+
+def getsection(section):
+    return conf.getsection(section)
 
 
 def has_option(section, key):

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -28,6 +28,8 @@ import sys
 
 from future import standard_library
 
+from six import iteritems
+
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 standard_library.install_aliases()
@@ -234,8 +236,27 @@ class AirflowConfigParser(ConfigParser):
         self._validate()
 
     def getsection(self, section):
+        """
+        Returns the section as a dict. Values are converted to int, float, bool
+        as required.
+        :param section: section from the config
+        :return: dict
+        """
         if section in self._sections:
-            return self._sections[section]
+            _section = self._sections[section]
+            for key, val in iteritems(self._sections[section]):
+                try:
+                    val = int(val)
+                except ValueError:
+                    try:
+                        val = float(val)
+                    except ValueError:
+                        if val.lower() in ('t', 'true'):
+                            val = True
+                        elif val.lower() in ('f', 'false'):
+                            val = False
+                _section[key] = val
+            return _section
 
         return None
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -155,6 +155,11 @@ Note that you can also run "Celery Flower", a web UI built on top of Celery,
 to monitor your workers. You can use the shortcut command ``airflow flower``
 to start a Flower web server.
 
+Some caveats:
+
+- Make sure to use a database backed result backend
+- Make sure to set a visibility timeout in [celery_broker_transport_options] that exceeds the ETA of your longest running task
+- Tasks can and consume resources, make sure your worker as enough resources to run `celeryd_concurrency` tasks
 
 Scaling Out with Dask
 '''''''''''''''''''''

--- a/scripts/ci/airflow_travis.cfg
+++ b/scripts/ci/airflow_travis.cfg
@@ -49,6 +49,12 @@ celery_result_backend = db+mysql://root@localhost/airflow
 flower_port = 5555
 default_queue = default
 
+[celery_broker_transport_options]
+visibility_timeout = 21600
+_test_only_bool = True
+_test_only_float = 12.0
+_test_only_string = this is a test
+
 [scheduler]
 job_heartbeat_sec = 1
 scheduler_heartbeat_sec = 5

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 from __future__ import print_function
-import os
 import unittest
+
+import six
 
 from airflow import configuration
 from airflow.configuration import conf
+
 
 class ConfTest(unittest.TestCase):
 
@@ -52,3 +54,13 @@ class ConfTest(unittest.TestCase):
         cfg_dict = conf.as_dict(display_sensitive=True, display_source=True)
         self.assertEqual(
             cfg_dict['testsection']['testkey'], ('testvalue', 'env var'))
+
+    def test_broker_transport_options(self):
+        section_dict = conf.getsection("celery_broker_transport_options")
+        self.assertTrue(isinstance(section_dict['visibility_timeout'], int))
+
+        self.assertTrue(isinstance(section_dict['_test_only_bool'], bool))
+
+        self.assertTrue(isinstance(section_dict['_test_only_float'], float))
+
+        self.assertTrue(isinstance(section_dict['_test_only_string'], six.string_types))


### PR DESCRIPTION
There's a [timeout issue with celery](https://issues.apache.org/jira/browse/AIRFLOW-1555) that's due to be fixed in Airflow `1.9.1`. We currently work around the issue by deploying our own [`celery-config`  branch](https://github.com/github/incubator-airflow/tree/celery-config), which is equivalent to upstream `1.8.2`, but with one [additional commit](https://github.com/github/incubator-airflow/commit/704d46da2d21aef493dc72a048023426cd7cd118) that eliminates the celery issue.

As part of [upgrading to Airflow `1.9.0`](https://github.com/github/airflow-sources/pull/849), this PR logs the tweaks we need to make to upstream `1.9.0` in order to keep the celery issue at bay. Rather than keep our old workaround, I've branched `gh-1.9.0` off upstream `1.9.0`, then cherry-picked the celery-related changes from `upstream/master` that will evidently be included in `1.9.1`.

What I'm not sure about yet is whether there's a not-too-hacky way to set `AIRFLOW__CELERY_BROKER_TRANSPORT_OPTIONS__VISIBILITY_TIMEOUT` without [updating puppet](https://github.com/github/puppet/blob/8e9894539a5b9629286180089b9e6df0ad29d245/modules/airflow/templates/home/deploy/airflow/airflow.properties.erb)? Then again, we may need to make other puppet changes as part of this upgrade anyways. (Looking into that shortly).

/cc @github/data-engineering 