### PR TITLE
Recognize extras in Connections defined by env vars

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -45,7 +45,7 @@ import textwrap
 import traceback
 import warnings
 import hashlib
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qsl
 
 from sqlalchemy import (
     Column, Integer, String, DateTime, Text, Boolean, ForeignKey, PickleType,
@@ -591,6 +591,8 @@ class Connection(Base, LoggingMixin):
         self.login = temp_uri.username
         self.password = temp_uri.password
         self.port = temp_uri.port
+        if temp_uri.query:
+            self.extra = json.dumps(dict(parse_qsl(temp_uri.query)))
 
     def get_password(self):
         if self._password and self.is_encrypted:


### PR DESCRIPTION
As mentioned in https://github.com/github/data-engineering/issues/722#issuecomment-396731531, this change will let us define all `Connection`s, including those with `extras`, as environment variables. 

/cc @github/data-engineering 