### PR TITLE
Remove explicit werkzeug requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -326,7 +326,6 @@ def do_setup():
             'thrift>=0.9.2',
             'tzlocal>=1.4',
             'unicodecsv>=0.14.1',
-            'werkzeug>=0.14.1, <0.15.0',
             'zope.deprecation>=4.0, <5.0',
         ],
         setup_requires=[


### PR DESCRIPTION
This PR removes `werkzeug` as an explicit requirement backporting these changes from  https://github.com/apache/airflow/pull/5535.

This should help us resolve a vulnerability alert https://github.com/github/airflow-sources/pull/2180 and remove our pinned version from `airflow-sources`

**ROLLOUT**

- [x] Test changes locally
- [x] Test changes in Airflow staging by pointing to the new branch.
- [ ] Check that the UI keeps rendering correctly and dependencies build correctly.
- [ ] Roll-out to Airflow production.