### PR TITLE
[AIRFLOW-5387] Handle showPaused URL param properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ This is a fork of [Airflow 1.10.3](https://github.com/apache/airflow/tree/1.10.3
 - Hide `Delete` button from the main Airflow page
 - Fix `bail.` button onclick action to redirect correctly to the DAG page
 - Fix `Mark Success` & `Mark Failed` functionality, it was not using the right `Future`, `Past`, `Downstream` & `Upstream` toggles.
+- Cherry pick changes to fix pagination when `showPaused=True` and `hide_paused_dags_by_default=True` https://github.com/apache/airflow/pull/6100

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -97,8 +97,8 @@ class DataProfilingMixin(object):
 
 
 def get_params(**kwargs):
-    hide_paused_dags_by_default = conf.getboolean('webserver',
-                                                  'hide_paused_dags_by_default')
+    hide_paused_dags_by_default = configuration.conf.getboolean('webserver',
+                                                                'hide_paused_dags_by_default')
     if 'showPaused' in kwargs:
         show_paused_dags_url_param = kwargs['showPaused']
         if _should_remove_show_paused_from_url_params(

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -97,11 +97,24 @@ class DataProfilingMixin(object):
 
 
 def get_params(**kwargs):
+    hide_paused_dags_by_default = conf.getboolean('webserver',
+                                                  'hide_paused_dags_by_default')
     if 'showPaused' in kwargs:
-        v = kwargs['showPaused']
-        if v or v is None:
+        show_paused_dags_url_param = kwargs['showPaused']
+        if _should_remove_show_paused_from_url_params(
+            show_paused_dags_url_param,
+            hide_paused_dags_by_default
+        ):
             kwargs.pop('showPaused')
     return urlencode({d: v if v is not None else '' for d, v in kwargs.items()})
+
+
+def _should_remove_show_paused_from_url_params(show_paused_dags_url_param,
+                                               hide_paused_dags_by_default):
+    return any([
+        show_paused_dags_url_param != hide_paused_dags_by_default,
+        show_paused_dags_url_param is None
+    ])
 
 
 def generate_pages(current_page, num_of_pages,

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -18,15 +18,18 @@
 # under the License.
 
 import functools
+import unittest
+from unittest import mock
+from parameterized import parameterized
+from urllib.parse import parse_qs
 
 from bs4 import BeautifulSoup
-import mock
 import six
-from six.moves.urllib.parse import parse_qs
 
 from airflow.www import app as application
 
 from airflow.www import utils
+from tests.test_utils.config import conf_vars
 
 if six.PY2:
     # Need `assertRegex` back-ported from unittest2
@@ -115,14 +118,38 @@ class UtilsTest(unittest.TestCase):
         self.assertEqual('search=bash_',
                          utils.get_params(search='bash_'))
 
-    def test_params_showPaused_true(self):
-        """Should detect True as default for showPaused"""
-        self.assertEqual('',
-                         utils.get_params(showPaused=True))
+    @parameterized.expand([
+        (True, False, ''),
+        (False, True, ''),
+        (True, True, 'showPaused=True'),
+        (False, False, 'showPaused=False'),
+        (None, True, ''),
+        (None, False, ''),
+    ])
+    def test_params_showPaused(self, show_paused, hide_by_default, expected_result):
+        with conf_vars({('webserver', 'hide_paused_dags_by_default'): str(hide_by_default)}):
+            self.assertEqual(expected_result,
+                             utils.get_params(showPaused=show_paused))
 
-    def test_params_showPaused_false(self):
-        self.assertEqual('showPaused=False',
-                         utils.get_params(showPaused=False))
+    @parameterized.expand([
+        (True, False, True),
+        (False, True, True),
+        (True, True, False),
+        (False, False, False),
+        (None, True, True),
+        (None, False, True),
+    ])
+    def test_should_remove_show_paused_from_url_params(self, show_paused,
+                                                       hide_by_default, expected_result):
+        with conf_vars({('webserver', 'hide_paused_dags_by_default'): str(hide_by_default)}):
+
+            self.assertEqual(
+                expected_result,
+                utils._should_remove_show_paused_from_url_params(
+                    show_paused,
+                    hide_by_default
+                )
+            )
 
     def test_params_none_and_zero(self):
         qs = utils.get_params(a=0, b=None)


### PR DESCRIPTION
This PR cherry-picks the changes applied [here](https://github.com/apache/airflow/pull/6100) to address part of the bug we were having with paginating when `hide_paused_dags=True` by default.

**TODO**
- [x] Test locally by switching development requirements to use this new branch
```
script/bootstrap
script/server
```
- [x] Test in staging opening a PR to modify requirements to use this new branch
```
.deploy airflow-sources/test-pagination-fixes to staging
https://airflow-staging.githubapp.com/
```
- [x] Merge

/cc @github/data-engineering 
https://github.com/github/airflow-sources/issues/2051