### PR TITLE
Cherry-pick from apache#5243 to address ZeroDivisionError exception

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -48,6 +48,7 @@ import zipfile
 import jinja2
 import json
 import logging
+import math
 import os
 import pendulum
 import pickle
@@ -1172,14 +1173,17 @@ class TaskInstance(Base, LoggingMixin):
         """
         delay = self.task.retry_delay
         if self.task.retry_exponential_backoff:
-            min_backoff = int(delay.total_seconds() * (2 ** (self.try_number - 2)))
+            # If the min_backoff calculation is below 1, it will be converted to 0 via int. Thus,
+            # we must round up prior to converting to an int, otherwise a divide by zero error
+            # will occurr in the modded_hash calculation.
+            min_backoff = int(math.ceil(delay.total_seconds() * (2 ** (self.try_number - 2))))
             # deterministic per task instance
             hash = int(hashlib.sha1("{}#{}#{}#{}".format(self.dag_id,
                                                          self.task_id,
                                                          self.execution_date,
                                                          self.try_number)
                                     .encode('utf-8')).hexdigest(), 16)
-            # between 0.5 * delay * (2^retry_number) and 1.0 * delay * (2^retry_number)
+            # between 1 and 1.0 * delay * (2^retry_number)
             modded_hash = min_backoff + hash % min_backoff
             # timedelta has a maximum representable value. The exponentiation
             # here means this value can be exceeded after a certain number

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2359,6 +2359,30 @@ class TaskInstanceTest(unittest.TestCase):
         dt = ti.next_retry_datetime()
         self.assertEqual(dt, ti.end_date + max_delay)
 
+    def test_next_retry_datetime_short_intervals(self):
+        delay = datetime.timedelta(seconds=1)
+        max_delay = datetime.timedelta(minutes=60)
+
+         dag = models.DAG(dag_id='fail_dag')
+        task = BashOperator(
+            task_id='task_with_exp_backoff_and_short_time_interval',
+            bash_command='exit 1',
+            retries=3,
+            retry_delay=delay,
+            retry_exponential_backoff=True,
+            max_retry_delay=max_delay,
+            dag=dag,
+            owner='airflow',
+            start_date=timezone.datetime(2016, 2, 1, 0, 0, 0))
+        ti = TI(
+            task=task, execution_date=DEFAULT_DATE)
+        ti.end_date = pendulum.instance(timezone.utcnow())
+
+         dt = ti.next_retry_datetime()
+        # between 1 * 2^0.5 and 1 * 2^1 (15 and 30)
+        period = ti.end_date.add(seconds=1) - ti.end_date.add(seconds=15)
+        self.assertTrue(dt in period)
+
     @patch.object(TI, 'pool_full')
     def test_reschedule_handling(self, mock_pool_full):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2363,7 +2363,7 @@ class TaskInstanceTest(unittest.TestCase):
         delay = datetime.timedelta(seconds=1)
         max_delay = datetime.timedelta(minutes=60)
 
-         dag = models.DAG(dag_id='fail_dag')
+        dag = models.DAG(dag_id='fail_dag')
         task = BashOperator(
             task_id='task_with_exp_backoff_and_short_time_interval',
             bash_command='exit 1',

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2378,7 +2378,7 @@ class TaskInstanceTest(unittest.TestCase):
             task=task, execution_date=DEFAULT_DATE)
         ti.end_date = pendulum.instance(timezone.utcnow())
 
-         dt = ti.next_retry_datetime()
+        dt = ti.next_retry_datetime()
         # between 1 * 2^0.5 and 1 * 2^1 (15 and 30)
         period = ti.end_date.add(seconds=1) - ti.end_date.add(seconds=15)
         self.assertTrue(dt in period)


### PR DESCRIPTION
Following PR cherry-picks the changes from https://github.com/apache/airflow/pull/5243 to address the `ZeroDivisionError` exception issue raised as part of https://github.com/github/airflow-sources/issues/2314

/cc @github/data-engineering 