### PR TITLE
Fix too many callback notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ This is a fork of [Airflow 1.10.3](https://github.com/apache/airflow/tree/1.10.3
 - Fix `bail.` button onclick action to redirect correctly to the DAG page
 - Fix `Mark Success` & `Mark Failed` functionality, it was not using the right `Future`, `Past`, `Downstream` & `Upstream` toggles.
 - Cherry pick changes to fix pagination when `showPaused=True` and `hide_paused_dags_by_default=True` https://github.com/apache/airflow/pull/6100
+- Fix too many notifications bug that would call the on failure notification callback on every scheduler loop https://github.com/github/airflow-sources/issues/2712
+

--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -802,7 +802,8 @@ class SchedulerJob(BaseJob):
                     dag.handle_callback(dr, success=False, reason='dagrun_timeout',
                                         session=session)
                     timedout_runs += 1
-            session.commit()
+                    session.merge(dr)
+                    session.commit()
             if len(active_runs) - timedout_runs >= dag.max_active_runs:
                 return
 


### PR DESCRIPTION
This PR puts together a fix for the problems we've been experiencing with Airflow sending away too many notifications whenever a DAG was failing.

More context can be found in [my comments here](https://github.com/github/airflow-sources/issues/2712#issuecomment-581442719)

## TODO
- [x] Validate changes locally (https://github.com/github/airflow-sources/issues/2712#issuecomment-582001468)
- [x] Get review from @github/data-engineering 
- [x] Test in staging
- [x] Test in Airflow production
- [ ] Rollout & Merge

/cc @github/data-engineering @bathompso @romanofoti 
https://github.com/github/airflow-sources/issues/2712
