### PR TITLE
Removed orphaned/broken symlinks that are causing 'pip download' failures

### DIFF
--- a/airflow/www/static/docs
+++ b/airflow/www/static/docs
@@ -1,1 +1,0 @@
-../../../docs/_build/html/

--- a/airflow/www_rbac/static/docs
+++ b/airflow/www_rbac/static/docs
@@ -1,1 +1,0 @@
-../../../docs/_build/html/


### PR DESCRIPTION
There are 2 orphaned/broken symlinks:

```
find . -xtype l
./airflow/www_rbac/static/docs
./airflow/www/static/docs

```
Both links point to the same missing destination:

```
# ls -al airflow/www_rbac/static/docs
lrwxrwxrwx 1 root root 26 Feb 24 19:31 airflow/www_rbac/static/docs -> ../../../docs/_build/html/
# ls -al airflow/www/static/docs
lrwxrwxrwx 1 root root 26 Feb 24 19:31 airflow/www/static/docs -> ../../../docs/_build/html/
```

During unpacking with `pip download` this causes the package download to fail because pip is trying to operations to perform and the navigation to the missing destination causes it to fail with an error:

> FileNotFoundError: [Errno 2] No such file or directory: '/src/apache-airflow/airflow/www_rbac/static/docs'

It appears this is still a feature of the [1.10-stable branch for airflow](https://github.com/apache/airflow/tree/v1-10-stable/airflow)
but has been resolved in [1.10-test](https://github.com/apache/airflow/tree/v1-10-test)

The broken link in www was [removed 6 days ago in 1.10-test](https://github.com/apache/airflow/commit/c43b49dffab3a2ef6cd5f4afb41c17c02d1f22c0#diff-24817fb76ca89b7a6a32163000f1afa3)

The broken link in www_rbac was [removed 8 days ago in 1.10-test](https://github.com/apache/airflow/commit/851bf819dbe7ba626f49885dca3532e4f4a49025#diff-45e5db72231fc091e71c4331d93a1c46)