### PR TITLE
Update import to fix warnings

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -25,7 +25,7 @@ from flask_admin import Admin, base
 from flask_caching import Cache
 from flask_wtf.csrf import CSRFProtect
 from six.moves.urllib.parse import urlparse
-from werkzeug.wsgi import DispatcherMiddleware
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from werkzeug.contrib.fixers import ProxyFix
 
 import airflow


### PR DESCRIPTION
Got sick of the same warning over and over again adding noise to the local dev command line.

The warning is:
```
/Users/tbries/source/airflow-sources/.venv/src/apache-airflow/airflow/www/app.py:193: DeprecationWarning: 'werkzeug.wsgi.DispatcherMiddleware' has moved to 'werkzeug.middleware.dispatcher.DispatcherMiddleware'. This import is deprecated as of version 0.15 and will be removed in version 1.0.
```

@preston-m-price I see you merged [a PR](https://github.com/github/incubator-airflow/pull/22) in this repo a while back. Is there anything I need to do for this change to propagate to the local dev environment once this change is merged?

cc: @github/data-engineering 