### PR TITLE
Meaningful tab titles for DAG-specific pages  

### DIFF
--- a/airflow/www/templates/airflow/chart.html
+++ b/airflow/www/templates/airflow/chart.html
@@ -16,7 +16,7 @@
 
 #}
 {% extends "airflow/dag.html" %}
-{% block title %}Tasks - {{ dag.dag_id }}{% endblock %}
+{% block title %}{{ block_title }} - {{ dag.dag_id }}{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www/templates/airflow/chart.html
+++ b/airflow/www/templates/airflow/chart.html
@@ -16,7 +16,7 @@
 
 #}
 {% extends "airflow/dag.html" %}
-{% block title %}Airflow - DAGs{% endblock %}
+{% block title %}Tasks - {{ dag.dag_id }}{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www/templates/airflow/dag_code.html
+++ b/airflow/www/templates/airflow/dag_code.html
@@ -16,7 +16,7 @@
 
 #}
 {% extends "airflow/dag.html" %}
-{% block title %}Airflow - DAGs{% endblock %}
+{% block title %}Code - {{ dag.dag_id }}{% endblock %}
 
 {% block body %}
     {{ super() }}

--- a/airflow/www/templates/airflow/dag_details.html
+++ b/airflow/www/templates/airflow/dag_details.html
@@ -16,6 +16,7 @@
 
 #}
 {% extends "airflow/dag.html" %}
+{% block title %}Details - {{ dag.dag_id }}{% endblock %}
 
 {% block title %}
     {{ title }}

--- a/airflow/www/templates/airflow/duration_chart.html
+++ b/airflow/www/templates/airflow/duration_chart.html
@@ -16,7 +16,7 @@
 
 #}
 {% extends "airflow/dag.html" %}
-{% block title %}Airflow - DAGs{% endblock %}
+{% block title %}Task Duration - {{ dag.dag_id }}{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -16,6 +16,7 @@
 
 #}
 {% extends "airflow/dag.html" %}
+{% block title %}Gantt - {{ dag.dag_id }}{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -19,7 +19,7 @@
 {% import 'admin/lib.html' as lib with context %}
 {% import 'admin/static.html' as admin_static with context %}
 
-{% block title %}Airflow - DAGs{% endblock %}
+{% block title %}Graph View - {{ dag.dag_id }}{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www/templates/airflow/task.html
+++ b/airflow/www/templates/airflow/task.html
@@ -16,7 +16,7 @@
 
 #}
 {% extends "airflow/task_instance.html" %}
-{% block title %}Airflow - DAGs{% endblock %}
+{% block title %}Details - {{task_id}}{% endblock %}
 
 {% block body %}
     {{ super() }}

--- a/airflow/www/templates/airflow/ti_code.html
+++ b/airflow/www/templates/airflow/ti_code.html
@@ -16,7 +16,7 @@
 
 #}
 {% extends "airflow/task_instance.html" %}
-{% block title %}Airflow - DAGs{% endblock %}
+{% block title %}Rendered - {{task_id}}{% endblock %}
 
 {% block body %}
     {{ super() }}

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 #}
 {% extends "airflow/task_instance.html" %}
-{% block title %}Airflow - DAGs{% endblock %}
+{% block title %}Log - {{task_id}}{% endblock %}
 
 {% block body %}
 {{ super() }}

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -16,7 +16,7 @@
 
 #}
 {% extends "airflow/dag.html" %}
-{% block title %}Airflow - DAGs{% endblock %}
+{% block title %}Tree View - {{ dag.dag_id }}{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www/templates/airflow/xcom.html
+++ b/airflow/www/templates/airflow/xcom.html
@@ -19,7 +19,7 @@
 #
 #}
 {% extends "airflow/task_instance.html" %}
-{% block title %}Airflow - DAGs{% endblock %}
+{% block title %}XCom - {{task_id}}{% endblock %}
 
 {% block body %}
     {{ super() }}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1807,7 +1807,8 @@ class Airflow(BaseView):
             demo_mode=conf.getboolean('webserver', 'demo_mode'),
             root=root,
             form=form,
-            chart=chart.htmlcontent
+            chart=chart.htmlcontent,
+            block_title='Task Tries'
         )
 
     @expose('/landing_times')
@@ -1886,6 +1887,7 @@ class Airflow(BaseView):
             demo_mode=conf.getboolean('webserver', 'demo_mode'),
             root=root,
             form=form,
+            block_title='Landing Times',
         )
 
     @expose('/paused', methods=['POST'])

--- a/airflow/www_rbac/templates/airflow/tree.html
+++ b/airflow/www_rbac/templates/airflow/tree.html
@@ -16,7 +16,7 @@
 
 #}
 {% extends "airflow/dag.html" %}
-{% block title %}Airflow - DAG {{ dag.dag_id }}{% endblock %}
+{% block title %}Airflow - DAGs{% endblock %}
 
 {% block head_css %}
 {{ super() }}

--- a/airflow/www_rbac/templates/airflow/tree.html
+++ b/airflow/www_rbac/templates/airflow/tree.html
@@ -16,7 +16,7 @@
 
 #}
 {% extends "airflow/dag.html" %}
-{% block title %}Airflow - DAGs{% endblock %}
+{% block title %}Airflow - DAG {{ dag.dag_id }}{% endblock %}
 
 {% block head_css %}
 {{ super() }}


### PR DESCRIPTION
Turning nearly all tab titles in the usual Airflow UI from:
![image](https://user-images.githubusercontent.com/26194700/80929397-8bcbfd80-8d60-11ea-99b3-544eb9a704f4.png)

To be more meaningful:
![image](https://user-images.githubusercontent.com/26194700/80929388-7ce54b00-8d60-11ea-8a5e-56a62fc283af.png) 
![image](https://user-images.githubusercontent.com/26194700/80929410-a2725480-8d60-11ea-998e-a74b83b5356a.png)
![image](https://user-images.githubusercontent.com/26194700/80929418-b1f19d80-8d60-11ea-8234-b8de6262dfde.png)
![image](https://user-images.githubusercontent.com/26194700/80929428-be75f600-8d60-11ea-97e2-c6d070267350.png)
![image](https://user-images.githubusercontent.com/26194700/80929430-c897f480-8d60-11ea-9b87-03e20bfe6c70.png)
![image](https://user-images.githubusercontent.com/26194700/80929432-d188c600-8d60-11ea-9d94-8b907f0fb626.png)

Each title consists of two parts:
1. What's being shown - 'Tree View', 'Graph', etc. Exact verbiage based on existing Airflow nomenclature.
1. Context of what is being shown, either the DAG or task name.   