### PR TITLE
Further improve DAG and Task tab names

### DIFF
--- a/airflow/www/templates/airflow/dag_details.html
+++ b/airflow/www/templates/airflow/dag_details.html
@@ -16,11 +16,7 @@
 
 #}
 {% extends "airflow/dag.html" %}
-{% block title %}Details - {{ dag.dag_id }}{% endblock %}
-
-{% block title %}
-    {{ title }}
-{% endblock %}
+{% block title %}DAG Details - {{ dag.dag_id }}{% endblock %}
 
 {% block body %}
     {{ super() }}

--- a/airflow/www/templates/airflow/task.html
+++ b/airflow/www/templates/airflow/task.html
@@ -16,7 +16,7 @@
 
 #}
 {% extends "airflow/task_instance.html" %}
-{% block title %}Details - {{task_id}}{% endblock %}
+{% block title %}Task Details - {{task_id}}{% endblock %}
 
 {% block body %}
     {{ super() }}


### PR DESCRIPTION
Specifying if the current tab is 'DAG' or 'Task' details to avoid confusing users.

As a follow up to https://github.com/github/incubator-airflow/pull/27