### PR TITLE
Merge accessible colors

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -157,15 +157,15 @@ json = json
 # Dictionary containing State and colors associated to each state to
 # display on the Webserver
 STATE_COLORS = {
-    "queued": 'darkgray',
-    "running": '#01FF70',
-    "success": '#2ECC40',
-    "failed": 'firebrick',
-    "up_for_retry": 'yellow',
-    "up_for_reschedule": 'turquoise',
-    "upstream_failed": 'orange',
-    "skipped": 'darkorchid',
-    "scheduled": 'tan',
+    "queued": "gray",
+    "running": "lime",
+    "success": "green",
+    "failed": "red",
+    "up_for_retry": "gold",
+    "up_for_reschedule": "turquoise",
+    "upstream_failed": "orange",
+    "skipped": "pink",
+    "scheduled": "tan",
 }
 
 def policy(task_instance):

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -154,6 +154,20 @@ Session = None
 json = json
 
 
+# Dictionary containing State and colors associated to each state to
+# display on the Webserver
+STATE_COLORS = {
+    "queued": "gray",
+    "running": "lime",
+    "success": "green",
+    "failed": "red",
+    "up_for_retry": "gold",
+    "up_for_reschedule": "turquoise",
+    "upstream_failed": "orange",
+    "skipped": "pink",
+    "scheduled": "tan",
+}
+
 def policy(task_instance):
     """
     This policy setting allows altering task instances right before they

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -157,15 +157,15 @@ json = json
 # Dictionary containing State and colors associated to each state to
 # display on the Webserver
 STATE_COLORS = {
-    "queued": "gray",
-    "running": "lime",
-    "success": "green",
-    "failed": "red",
-    "up_for_retry": "gold",
-    "up_for_reschedule": "turquoise",
-    "upstream_failed": "orange",
-    "skipped": "pink",
-    "scheduled": "tan",
+    "queued": 'darkgray',
+    "running": '#01FF70',
+    "success": '#2ECC40',
+    "failed": 'firebrick',
+    "up_for_retry": 'yellow',
+    "up_for_reschedule": 'turquoise',
+    "upstream_failed": 'orange',
+    "skipped": 'darkorchid',
+    "scheduled": 'tan',
 }
 
 def policy(task_instance):

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -17,8 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from airflow.settings import STATE_COLORS
 from __future__ import unicode_literals
+from airflow.settings import STATE_COLORS
 
 from builtins import object
 

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+from airflow.settings import STATE_COLORS
 from __future__ import unicode_literals
 
 from builtins import object
@@ -80,6 +81,7 @@ class State(object):
         SCHEDULED: 'tan',
         NONE: 'lightblue',
     }
+    state_color.update(STATE_COLORS) # type: ignore
 
     @classmethod
     def color(cls, state):

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -39,6 +39,7 @@ from airflow.logging_config import configure_logging
 from airflow import jobs
 from airflow import settings
 from airflow.utils.net import get_hostname
+from airflow.settings import STATE_COLORS
 
 csrf = CSRFProtect()
 
@@ -189,7 +190,8 @@ def create_app(config=None, testing=False):
                 'log_auto_tailing_offset': conf.getint(
                     'webserver', 'log_auto_tailing_offset', fallback=30),
                 'log_animation_speed': conf.getint(
-                    'webserver', 'log_animation_speed', fallback=1000)
+                    'webserver', 'log_animation_speed', fallback=1000),
+                'state_color_mapping': STATE_COLORS
             }
 
         @app.before_request

--- a/airflow/www/templates/admin/master.html
+++ b/airflow/www/templates/admin/master.html
@@ -23,6 +23,13 @@
   <link href="{{ url_for('static', filename='bootstrap-theme.css') }}" rel="stylesheet">
   <link rel="icon" type="image/png" href="{{ url_for("static", filename="pin_32.png") }}">
   <link rel="stylesheet" type="text/css" href="{{ url_for("static", filename="main.css") }}">
+  <style type="text/css">
+    {% for state, state_color in state_color_mapping.items() %}
+      span.{{state}} {
+      background-color: {{state_color}};
+    }
+   {% endfor %}
+  </style>
 {% endblock %}
 
 {% block tail_js %}

--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -25,6 +25,13 @@
 <link href="{{ admin_static.url(filename='vendor/bootstrap-daterangepicker/daterangepicker-bs2.css') }}" rel="stylesheet"/>
 <link type="text/css" href="{{ url_for('static', filename='gantt.css') }}" rel="stylesheet" />
 <link type="text/css" href="{{ url_for('static', filename='tree.css') }}" rel="stylesheet" />
+<style type="text/css">
+    {% for state, state_color in state_color_mapping.items() %}
+      rect.{{state}} {
+        fill: {{state_color}};
+      }
+    {% endfor %}
+  </style>
 {% endblock %}
 
 {% block body %}

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -27,6 +27,13 @@
 {{ super() }}
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='dagre.css') }}">
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='graph.css') }}">
+<style type="text/css">
+  {% for state, state_color in state_color_mapping.items() %}
+    g.node.{{state}} rect {
+    stroke: {{state_color}};
+  }
+{% endfor %}
+</style>
 {% endblock %}
 
 {% block body %}
@@ -64,14 +71,9 @@
 
   <div>
     <div class="legend_item state" style="border-color:white;">no_status</div>
-    <div class="legend_item state" style="border-color:darkgray;">queued</div>
-    <div class="legend_item state" style="border-color:yellow;">up_for_retry</div>
-    <div class="legend_item state" style="border-color:turquoise;">up_for_reschedule</div>
-    <div class="legend_item state" style="border-color:orange;">upstream_failed</div>
-    <div class="legend_item state" style="border-color:darkorchid;">skipped</div>
-    <div class="legend_item state" style="border-color:firebrick;">failed</div>
-    <div class="legend_item state" style="border-color:lime;">running</div>
-    <div class="legend_item state" style="border-color:green;">success</div>
+    {% for state, state_color in state_color_mapping.items() %}
+      <div class="legend_item state" style="border-color:{{state_color}};">{{state}}</div>
+    {% endfor %}
   </div>
   <div style="clear:both;"></div>
 </div>

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -24,6 +24,13 @@
 {{ super() }}
 <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='tree.css') }}">
 <link href="{{ admin_static.url(filename='vendor/bootstrap-daterangepicker/daterangepicker-bs2.css') }}" rel="stylesheet">
+<style type="text/css">
+  {% for state, state_color in state_color_mapping.items() %}
+    rect.{{state}} {
+      fill: {{state_color}};
+    }
+  {% endfor %}
+</style>
 {% endblock %}
 
 {% block body %}
@@ -43,22 +50,10 @@
 <div>
   <div class="legend_item" style="border: none;">no_status</div>
   <div class="square" style="background: white;"></div>
-  <div class="legend_item" style="border: none;">queued</div>
-  <div class="square" style="background: darkgray;"></div>
-  <div class="legend_item" style="border: none;">up_for_retry</div>
-  <div class="square" style="background: yellow;"></div>
-  <div class="legend_item" style="border: none;">up_for_reschedule</div>
-  <div class="square" style="background: turquoise;"></div>
-  <div class="legend_item" style="border: none;">upstream_failed</div>
-  <div class="square" style="background: orange;"></div>
-  <div class="legend_item" style="border: none;">skipped</div>
-  <div class="square" style="background: darkorchid;"></div>
-  <div class="legend_item" style="border: none;">failed</div>
-  <div class="square" style="background: firebrick;"></div>
-  <div class="legend_item" style="border: none;">running</div>
-  <div class="square" style="background: lime;"></div>
-  <div class="legend_item" style="border: none;">success</div>
-  <div class="square" style="background: green;"></div>
+  {% for state, state_color in state_color_mapping.items() %}
+    <div class="legend_item" style="border: none;">{{state}}</div>
+    <div class="square" style="background: {{state_color}};"></div>
+  {% endfor %}
   {% for op in operators %}
   <div class="legend_circle" style="background:{{ op.ui_color }};">
   </div>


### PR DESCRIPTION
The upstream Apache airflow repo has[ merged](https://github.com/apache/airflow/pull/9520) changes to make configuring accessible colors easier, and I wanted to bring those changes into our fork. They took some of my advice on colors, but changed the default success color, which made other colors harder for me to see.

This is a nearly direct port of the upstream PR, but we don't have the global jinja config, so I opted to inject the STATE_COLORS in `app.py` rather than bringing along all the necessary changes to support the jinja config.

### Stock Colors/Config
![image](https://user-images.githubusercontent.com/5125809/86824500-723e7f00-c04b-11ea-9d5e-e2e99dacb369.png)
![image](https://user-images.githubusercontent.com/5125809/86824579-8e422080-c04b-11ea-8633-bd4d17883c8d.png)
![image](https://user-images.githubusercontent.com/5125809/86824599-99954c00-c04b-11ea-9430-32514c17b117.png)


### Proposed Colors/Config
Their proposed changes still need some tuning for me, so I propose adding the following to airflow_local_settings in airflow_sources once we merge this in:
```
from airflow.utils.state import State
...
STATE_COLORS = {
    "queued": 'lightgray',
    "running": '#01FF70',
    "success": '#2ECC40',
    "failed": 'firebrick',
    "up_for_retry": 'yellow',
    "up_for_reschedule": 'turquoise',
    "upstream_failed": 'orange',
    "skipped": 'darkorchid',
    "scheduled": 'khaki',
}
State.state_color.update(STATE_COLORS)
```
![image](https://user-images.githubusercontent.com/5125809/86824809-dfeaab00-c04b-11ea-86c1-041362153001.png)
![image](https://user-images.githubusercontent.com/5125809/86838826-e08c3d00-c05d-11ea-9524-f929ce0c97f0.png)
![image](https://user-images.githubusercontent.com/5125809/86838993-14676280-c05e-11ea-8e49-1897019e917c.png)


### Other Notes
I tried following the advice/docs given in their [customize_state_colors howto](https://github.com/apache/airflow/blob/master/docs/howto/customize-state-colors-ui.rst) by placing our desired changes to `STATE_COLORS` in `airflow_local_settings` but the only way I can get these changes picked up is to monkey-patch the `airflow.utils.State` class. Otherwise, the `airflow.utils.state` class is always evaluated with stock settings before our `airflow_local_settings` modifications are made. There is an order-of-operations issue here that I don't grok, thanks to @kimyen for trying to help me through this.

You may notice that I didn't make corresponding changes from `www` in `www_rbac`. The upstream PR doesn't make changes there because `www_rbac` no longer exists upstream, and I don't believe we are making any use of it.