### PR TITLE
Adding code to hide the trigger dag btn.

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -123,11 +123,12 @@
                 <td class="text-center" style="display:flex; flex-direction:row; justify-content:space-around;">
                 {% if dag %}
 
-                <!-- Trigger Dag -->
+                <!-- Trigger Dag 
                 <a href="{{ url_for('airflow.trigger', dag_id=dag.dag_id) }}&origin={{ request.base_url }}"
                    onclick="return confirmTriggerDag(this, '{{ dag.safe_dag_id }}')">
                     <span class="glyphicon glyphicon-play-circle" aria-hidden="true" data-original-title="Trigger Dag"></span>
                 </a>
+                -->
 
                 <!-- Tree -->
                 <a href="{{ url_for('airflow.tree', dag_id=dag.dag_id, num_runs=num_runs) }}">

--- a/airflow/www_rbac/templates/airflow/dag.html
+++ b/airflow/www_rbac/templates/airflow/dag.html
@@ -99,7 +99,7 @@
           Code
         </a>
       </li>
-      <li>
+      <li style="display: none;">
         <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=url_for('Airflow.tree', dag_id=dag.dag_id)) }}"
           onclick="return confirmTriggerDag(this, '{{ dag.safe_dag_id }}')">
           <span class="glyphicon glyphicon-play-circle" aria-hidden="true"></span>

--- a/airflow/www_rbac/templates/airflow/dags.html
+++ b/airflow/www_rbac/templates/airflow/dags.html
@@ -138,11 +138,12 @@
                 <td class="text-center" style="display:flex; flex-direction:row; justify-content:space-around;">
                 {% if dag %}
 
-                <!-- Trigger Dag -->
+                <!-- Trigger Dag
                 <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id) }}&origin={{ request.base_url }}"
                    onclick="return confirmTriggerDag(this, '{{ dag.safe_dag_id }}')">
                     <span class="glyphicon glyphicon-play-circle" aria-hidden="true" data-original-title="Trigger Dag"></span>
                 </a>
+                -->
 
                 <!-- Tree -->
                 <a href="{{ url_for('Airflow.tree', dag_id=dag.dag_id, num_runs=num_runs) }}">


### PR DESCRIPTION
I'm following previous solution of `comment out the button`.
This change does not remove the `Trigger Dag Run` functionality from the API.

## Before
![image](https://user-images.githubusercontent.com/5125809/87091067-4ad7e580-c1f6-11ea-9a28-25e9d0f98012.png)

## After
![image](https://user-images.githubusercontent.com/5125809/87091337-b91ca800-c1f6-11ea-9ea5-7044f8936474.png)


cc: @github/data-engineering 