### PR TITLE
updates task lookup algorithm attempt to avoid long query

### DIFF
--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -651,14 +651,27 @@ class AirflowKubernetesScheduler(LoggingMixin):
                     'severe performance regressions. Please see '
                     '<https://kubernetes.io/docs/concepts/overview/working-with-objects'
                     '/labels/#syntax-and-character-set>. '
-                    'Given dag_id: %s, task_id: %s', task_id, dag_id
+                    'Given dag_id: %s, task_id: %s', dag_id, task_id
                 )
-
-            tasks = (
-                session
-                .query(TaskInstance)
-                .filter_by(execution_date=ex_time).all()
-            )
+            # attempt to avoid the extremely slow path by seeing if dag_id is valid to be added to
+            # search query
+            # if the dag_id comes back from the `safe_label` code unchanged, it is already a valid label
+            if self._make_safe_label_value(dag_id) == dag_id:
+                self.log.info('Attempting enhanced slow-path lookup as dag_id appears to be a valid K8 label')
+                tasks = (
+                    session
+                    .query(TaskInstance)
+                    .filter_by(dag_id=dag_id, execution_date=ex_time)
+                    .all()
+                )
+            else:
+                self.log.warning('Normal slow-path lookup must be used to find tasks')
+                tasks = (
+                    session
+                    .query(TaskInstance)
+                    .filter_by(execution_date=ex_time)
+                    .all()
+                )
             self.log.info(
                 'Checking %s task instances.',
                 len(tasks)


### PR DESCRIPTION
Attempts to fix https://github.com/github/data/issues/604 by enhancing the task lookup queries to avoid the extremely slow path when the task_id is too long to be a valid K8 label