### PR TITLE
Add Context comments to Presto check & SQL sensor operators

### DIFF
--- a/airflow/operators/presto_check_operator.py
+++ b/airflow/operators/presto_check_operator.py
@@ -23,6 +23,7 @@ from airflow.operators.check_operator import CheckOperator, \
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.helpers import add_airflow_context_comment
 
+
 class PrestoCheckOperator(CheckOperator):
     """
     Performs checks against Presto. The ``PrestoCheckOperator`` expects

--- a/airflow/operators/presto_check_operator.py
+++ b/airflow/operators/presto_check_operator.py
@@ -74,7 +74,7 @@ class PrestoCheckOperator(CheckOperator):
     def pre_execute(self, context):
         self.sql = add_airflow_context_comment(context, self.sql)
 
-        super(PrestoCheckOperator, self).pre_execute(self, context)
+        super(PrestoCheckOperator, self).pre_execute(context)
 
 class PrestoValueCheckOperator(ValueCheckOperator):
     """
@@ -102,7 +102,7 @@ class PrestoValueCheckOperator(ValueCheckOperator):
     def pre_execute(self, context):
         self.sql = add_airflow_context_comment(context, self.sql)
 
-        super(PrestoValueCheckOperator, self).pre_execute(self, context)
+        super(PrestoValueCheckOperator, self).pre_execute(context)
 
 
 class PrestoIntervalCheckOperator(IntervalCheckOperator):
@@ -140,4 +140,4 @@ class PrestoIntervalCheckOperator(IntervalCheckOperator):
         self.sql1 = add_airflow_context_comment(context, self.sql1)
         self.sql2 = add_airflow_context_comment(context, self.sql2)
 
-        super(PrestoIntervalCheckOperator, self).pre_execute(self, context)
+        super(PrestoIntervalCheckOperator, self).pre_execute(context)

--- a/airflow/operators/presto_check_operator.py
+++ b/airflow/operators/presto_check_operator.py
@@ -21,7 +21,7 @@ from airflow.hooks.presto_hook import PrestoHook
 from airflow.operators.check_operator import CheckOperator, \
     ValueCheckOperator, IntervalCheckOperator
 from airflow.utils.decorators import apply_defaults
-
+from airflow.utils.helpers import add_airflow_context_comment
 
 class PrestoCheckOperator(CheckOperator):
     """
@@ -70,6 +70,10 @@ class PrestoCheckOperator(CheckOperator):
     def get_db_hook(self):
         return PrestoHook(presto_conn_id=self.presto_conn_id)
 
+    def pre_execute(self, context):
+        self.sql = add_airflow_context_comment(context, self.sql)
+
+        super(PrestoCheckOperator, self).pre_execute(self, context)
 
 class PrestoValueCheckOperator(ValueCheckOperator):
     """
@@ -93,6 +97,11 @@ class PrestoValueCheckOperator(ValueCheckOperator):
 
     def get_db_hook(self):
         return PrestoHook(presto_conn_id=self.presto_conn_id)
+
+    def pre_execute(self, context):
+        self.sql = add_airflow_context_comment(context, self.sql)
+
+        super(PrestoValueCheckOperator, self).pre_execute(self, context)
 
 
 class PrestoIntervalCheckOperator(IntervalCheckOperator):
@@ -125,3 +134,9 @@ class PrestoIntervalCheckOperator(IntervalCheckOperator):
 
     def get_db_hook(self):
         return PrestoHook(presto_conn_id=self.presto_conn_id)
+
+    def pre_execute(self, context):
+        self.sql1 = add_airflow_context_comment(context, self.sql1)
+        self.sql2 = add_airflow_context_comment(context, self.sql2)
+
+        super(PrestoIntervalCheckOperator, self).pre_execute(self, context)

--- a/airflow/sensors/sql_sensor.py
+++ b/airflow/sensors/sql_sensor.py
@@ -24,6 +24,7 @@ from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.helpers import add_airflow_context_comment
 
 
 class SqlSensor(BaseSensorOperator):
@@ -85,9 +86,10 @@ class SqlSensor(BaseSensorOperator):
 
     def poke(self, context):
         hook = self._get_hook()
+        commented_sql = add_airflow_context_comment(context, self.sql)
 
-        self.log.info('Poking: %s (with parameters %s)', self.sql, self.parameters)
-        records = hook.get_records(self.sql, self.parameters)
+        self.log.info('Poking: %s (with parameters %s)', commented_sql, self.parameters)
+        records = hook.get_records(commented_sql, self.parameters)
         if not records:
             if self.fail_on_empty:
                 raise AirflowException("No rows returned, raising as per fail_on_empty flag")

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -497,11 +497,9 @@ def generate_airflow_context_comment(context):
     """
     Generates a comment to SQL and HQL queries detailing the current Airflow context.
 
-    The comment format is:
-    -- Airflow Context: {dag_id}.{task_id}.{operator}.{execution_date}
-
-    Example:
-    -- Airflow Context: test_dag.test_presto_operator.PrestoOperator.2020-11-16T00:00:00+00:00
+    Example: (actual context is all on one line)
+    -- Airflow Context: {'dag_id': 'test_dag', 'task_id': 'test_presto_operator',
+    'operator': 'PrestoOperator', 'execution_date': '2020-11-16T00:00:00+00:00'}
 
     :param context: Airflow context
     :type context: Airflow context
@@ -510,19 +508,23 @@ def generate_airflow_context_comment(context):
     if ti is None:
         return None
 
-    return '-- Airflow Context: {}.{}.{}.{}' \
-        .format(ti.dag_id, ti.task_id, ti.operator, ti.execution_date.isoformat())
+    airflow_context = {
+        'dag_id': ti.dag_id,
+        'task_id': ti.task_id,
+        'operator': ti.operator,
+        'execution_date': ti.execution_date.isoformat()
+    }
+
+    return '-- Airflow Context: {}'.format(airflow_context)
 
 
 def add_airflow_context_comment(context, query):
     """
     Adds a comment to SQL and HQL queries detailing the current Airflow context.
 
-    The comment format is:
-    -- Airflow Context: {dag_id}.{task_id}.{operator}.{execution_date}
-
-    Example:
-    -- Airflow Context: test_dag.test_presto_operator.PrestoOperator.2020-11-16T00:00:00+00:00
+    Example: (actual context is all on one line)
+    -- Airflow Context: {'dag_id': 'test_dag', 'task_id': 'test_presto_operator',
+    'operator': 'PrestoOperator', 'execution_date': '2020-11-16T00:00:00+00:00'}
 
     :param context: Airflow context
     :type context: Airflow context


### PR DESCRIPTION
As a follow up to https://github.com/github/airflow-sources/pull/4969, this pull request is adding the same Airflow context comment functionality to the following operators:
- `PrestoCheckOperator`
- `PrestoValueCheckOperator`
- `PrestoIntervalCheckOperator`
- `SqlSensor`

These are common operators in https://github.com/github/airflow-sources and this will give us more insights into which DAGs are reading from a certain table and vice versa.

I have tested these changes in my local dev environment by using this branch and the operators behave exactly as expected.

cc: @github/data-engineering 