### PR TITLE
address slow path task lookup in k8

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -611,7 +611,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
             # attempt to avoid the extremely slow path by seeing if dag_id is valid to be added to
             # search query
             # if the dag_id comes back from the `safe_label` code unchanged, it is already a valid label
-            if self._make_safe_label_value(dag_id) == dag_id:
+            if pod_generator.make_safe_label_value(dag_id) == dag_id:
                 self.log.info('Attempting enhanced slow-path lookup as dag_id appears to be a valid K8 label')
                 tasks = (
                     session

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -608,12 +608,25 @@ class AirflowKubernetesScheduler(LoggingMixin):
                     '/labels/#syntax-and-character-set>. '
                     'Given dag_id: %s, task_id: %s', task_id, dag_id
                 )
-
-            tasks = (
-                session
-                .query(TaskInstance)
-                .filter_by(execution_date=ex_time).all()
-            )
+            # attempt to avoid the extremely slow path by seeing if dag_id is valid to be added to
+            # search query
+            # if the dag_id comes back from the `safe_label` code unchanged, it is already a valid label
+            if self._make_safe_label_value(dag_id) == dag_id:
+                self.log.info('Attempting enhanced slow-path lookup as dag_id appears to be a valid K8 label')
+                tasks = (
+                    session
+                    .query(TaskInstance)
+                    .filter_by(dag_id=dag_id, execution_date=ex_time)
+                    .all()
+                )
+            else:
+                self.log.warning('Normal slow-path lookup must be used to find tasks')
+                tasks = (
+                    session
+                    .query(TaskInstance)
+                    .filter_by(execution_date=ex_time)
+                    .all()
+                )
             self.log.info(
                 'Checking %s task instances.',
                 len(tasks)


### PR DESCRIPTION
Patches 1.10.15 to fix the same flawed loop in the k8executor we had to fix in https://github.com/github/incubator-airflow/pull/43.   Enhances the task lookup queries to avoid the extremely slow path when the task_id is too long to be a valid K8 label (as is common with our very long task names)