### PR TITLE
Update _build_metrics in action_logging in airflow.utils.cli

### DIFF
--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -113,6 +113,7 @@ def _build_metrics(func_name, namespace):
     sub_commands_to_check = {'users', 'connections'}
     sensitive_fields = {'-p', '--password', '--conn-password'}
     full_command = list(sys.argv)
+    full_command.append("fake_value")
     if full_command[1] in sub_commands_to_check:  # pylint: disable=too-many-nested-blocks
         for idx, command in enumerate(full_command):
             if command in sensitive_fields:


### PR DESCRIPTION
Currently the behavior of `_build_metrics` leads to a `IndexError: list index out of range` when trying to access a value that does not exist for `full_command`, since` full_command = list(sys.argv) = ['']`.

I have added another fake value to the list to see let line 117 succeed without an IndexError. 
