### PR TITLE
pass along the backfill command pool to the task instance

### DIFF
--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -535,6 +535,9 @@ class BackfillJob(BaseJob):
                         ):
                             cfg_path = tmp_configuration_copy()
 
+                        # pass along the backfill command pool arg to the ti
+                        if self.pool:
+                            ti.pool = self.pool
                         executor.queue_task_instance(
                             ti,
                             mark_success=self.mark_success,


### PR DESCRIPTION
To be used together with adding new pool for backfill in airflow-sources and prevent task instance from being assigned to a pool by its operator.