### PR TITLE
Improvement to backfill 

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -66,6 +66,8 @@ def dag_backfill(args, dag=None):
         args.ignore_first_depends_on_past = True
 
     dag = dag or get_dag(args.subdir, args.dag_id)
+    if not dag.is_paused:
+        raise AirflowException("DAG is currently being scheduled. Please pause the DAG before running backfill.")
 
     if not args.start_date and not args.end_date:
         raise AirflowException("Provide a start_date and/or end_date")

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -696,6 +696,9 @@ class BackfillJob(BaseJob):
 
         return err
 
+    def _get_dag_with_subdags(self):
+        return [self.dag] + self.dag.subdags
+
     @provide_session
     def _execute_for_run_dates(self, run_dates, ti_status, executor, pickle_id, start_date, session=None):
         """
@@ -717,7 +720,7 @@ class BackfillJob(BaseJob):
         :type session: sqlalchemy.orm.session.Session
         """
         for next_run_date in run_dates:
-            for dag in [self.dag] + self.dag.subdags:
+            for dag in self._get_dag_with_subdags():
                 dag_run = self._get_dag_run(next_run_date, dag, session=session)
                 tis_map = self._task_instances_for_dag_run(dag_run, session=session)
                 if dag_run is None:
@@ -776,6 +779,32 @@ class BackfillJob(BaseJob):
 
         if len(run_dates) == 0:
             self.log.info("No run dates were found for the given dates and dag interval.")
+            return
+
+        dag_with_subdags_ids = [d.dag_id for d in self._get_dag_with_subdags()]
+        running_dagruns = DagRun.find(
+            dag_id=dag_with_subdags_ids,
+            execution_start_date=self.bf_start_date,
+            execution_end_date=self.bf_end_date,
+            no_backfills=True,
+            state=State.RUNNING,
+        )
+
+        if running_dagruns:
+            for run in running_dagruns:
+                self.log.error(
+                    "Backfill cannot be created for DagRun %s in %s, as there's already %s in a RUNNING "
+                    "state.",
+                    run.run_id,
+                    run.execution_date.strftime("%Y-%m-%dT%H:%M:%S"),
+                    run.run_type,
+                )
+            self.log.error(
+                "Changing DagRun into BACKFILL would cause scheduler to lose track of executing "
+                "tasks. Not changing DagRun type into BACKFILL, and trying insert another DagRun into "
+                "database would cause database constraint violation for dag_id + execution_date "
+                "combination. Please adjust backfill dates or wait for this DagRun to finish.",
+            )
             return
 
         # picklin'

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -243,7 +243,11 @@ class BackfillJob(BaseJob):
                     ti,
                 )
                 tis_to_be_scheduled.append(ti)
-                ti_status.running.pop(reduced_key)
+                try:
+                    ti_status.running.pop(reduced_key)
+                except KeyError:
+                    # the task is not running
+                    pass
                 ti_status.to_run[ti.key] = ti
 
         # Batch schedule of task instances


### PR DESCRIPTION
This PR includes the following improvements to the backfill command in Airflow 2:
- fail fast on DAG that is not paused
- roll back on deadlock
- fail fast on backfilling explicit DAG runs that is working on by the scheduler (even after the DAG is paused)
- fix backfill crashing when attempt to remove a not running task from running list