### PR TITLE
Ensure backfill won't crash

### DIFF
--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -211,32 +211,38 @@ class BackfillJob(BaseJob):
         if filter_for_tis is not None:
             refreshed_tis = session.query(TI).filter(filter_for_tis).all()
 
+        self.log.debug("ti_status: %s", ti_status)
         for ti in refreshed_tis:
             # Here we remake the key by subtracting 1 to match in memory information
             reduced_key = ti.key.reduced
             if ti.state == State.SUCCESS:
                 ti_status.succeeded.add(reduced_key)
                 self.log.debug("Task instance %s succeeded. Don't rerun.", ti)
+                self.log.debug("reduced_key: %s", reduced_key)
                 _pop_running_ti(ti_status, reduced_key)
                 continue
             if ti.state == State.SKIPPED:
                 ti_status.skipped.add(reduced_key)
                 self.log.debug("Task instance %s skipped. Don't rerun.", ti)
+                self.log.debug("reduced_key: %s", reduced_key)
                 _pop_running_ti(ti_status, reduced_key)
                 continue
             if ti.state == State.FAILED:
                 self.log.error("Task instance %s failed", ti)
+                self.log.debug("reduced_key: %s", reduced_key)
                 ti_status.failed.add(reduced_key)
                 _pop_running_ti(ti_status, reduced_key)
                 continue
             # special case: if the task needs to run again put it back
             if ti.state == State.UP_FOR_RETRY:
                 self.log.warning("Task instance %s is up for retry", ti)
+                self.log.debug("reduced_key: %s", reduced_key)
                 _pop_running_ti(ti_status, reduced_key)
                 ti_status.to_run[ti.key] = ti
             # special case: if the task needs to be rescheduled put it back
             elif ti.state == State.UP_FOR_RESCHEDULE:
                 self.log.warning("Task instance %s is up for reschedule", ti)
+                self.log.debug("reduced_key: %s", reduced_key)
                 _pop_running_ti(ti_status, reduced_key)
                 ti_status.to_run[ti.key] = ti
             # special case: The state of the task can be set to NONE by the task itself
@@ -250,6 +256,7 @@ class BackfillJob(BaseJob):
                     "reaching concurrency limits. Re-adding task to queue.",
                     ti,
                 )
+                self.log.debug("reduced_key: %s", reduced_key)
                 tis_to_be_scheduled.append(ti)
                 _pop_running_ti(ti_status, reduced_key)
                 ti_status.to_run[ti.key] = ti

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -50,6 +50,14 @@ from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
 
+def _pop_running_ti(ti_status, reduced_key):
+    try:
+        ti_status.running.pop(reduced_key)
+    except KeyError:
+        # the task is not running tracking dict
+        pass
+
+
 class BackfillJob(BaseJob):
     """
     A backfill job consists of a dag or subdag for a specific time range. It
@@ -185,15 +193,6 @@ class BackfillJob(BaseJob):
         self.rerun_failed_tasks = rerun_failed_tasks
         self.run_backwards = run_backwards
         super().__init__(*args, **kwargs)
-
-
-def _pop_running_ti(ti_status, reduced_key):
-    try:
-        ti_status.running.pop(reduced_key)
-    except KeyError:
-        # the task is not running tracking dict
-        pass
-
 
     @provide_session
     def _update_counters(self, ti_status, session=None):


### PR DESCRIPTION
This is to prevent errors like:
```
    session=session,
  File "/usr/local/lib/python3.7/site-packages/airflow/utils/session.py", line 67, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/airflow/jobs/backfill_job.py", line 631, in _process_backfill_task_instances
    self._update_counters(ti_status=ti_status)
  File "/usr/local/lib/python3.7/site-packages/airflow/utils/session.py", line 70, in wrapper
    return func(*args, session=session, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/airflow/jobs/backfill_job.py", line 227, in _update_counters
    ti_status.running.pop(reduced_key)
KeyError: TaskInstanceKey(dag_id='canonical_client_360_mobile_combined', task_id='amend_cube_metrics_mobile_combined', execution_date=datetime.datetime(2021, 9, 9, 0, 0, tzinfo=Timezone('UTC')), try_number=1)
```